### PR TITLE
Update language-scala.cson

### DIFF
--- a/scoped-properties/language-scala.cson
+++ b/scoped-properties/language-scala.cson
@@ -1,6 +1,6 @@
 '.source.scala':
   'editor':
-    'increaseIndentPattern': '(^.*(\\{[^}]*|\\([^)]*)$)'
+    'increaseIndentPattern': '(^.*(\\{[^}]*|\\([^)]*)$|^.*\\=\\s*$)'
     'decreaseIndentPattern': '^\\s*(\\}|\\))'
 '.keyword.other.documentation.scaladoc.scala':
   'editor':


### PR DESCRIPTION
Adding support for line indentation following a = with whitespace following.

Increases indent pattern following this type of line

```
def sqrt(x: Double) =
```

Have not extensively tested it, but am using it in my own .scala grammar
