### PR TITLE
Fix end match regex for import statements.

### DIFF
--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -421,7 +421,7 @@
     'beginCaptures':
       '1':
         'name': 'keyword.other.import.scala'
-    'end': '(?<=[\\n;])'
+    'end': '([\\n;]+)'
     'name': 'meta.import.scala'
     'patterns': [
       {


### PR DESCRIPTION
I was having issues with the package not matching newlines as valid endings for import statements. I don't have a lot of experience with regex, but I tested this [here](http://regex101.com/r/kZ9wT7/1) as well as locally in my editor.
