### PR TITLE
Styling to highlight 'var' usage in scala code.

### DIFF
--- a/styles/highlighting.less
+++ b/styles/highlighting.less
@@ -1,0 +1,5 @@
+@import "ui-variables";
+
+atom-text-editor::shadow .keyword.declaration.volatile.scala {
+  color: red;
+}


### PR DESCRIPTION
I prefer to handle vars and vals differently. Having a different highlight for 'var' is very useful to ensure that I treat it with respect, or preferably to simply remove it all together.

This is very much an initial pass at all of this as I'm only toying with Atom at the moment, so please advise if anything needs to change. This change does make the Atom scala language highlight the same as in other editors (eg: emacs).
