### PR TITLE
Fix prefixed string handling

### DIFF
--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -102,7 +102,7 @@
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.scala'
-        'end': '"""'
+        'end': '"""(?!")'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.scala'

--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -76,97 +76,50 @@
   'interpolation-expression' :
     'patterns': [
       {
-        'name': "interpolation.expression.embedded"
+        'name': 'source.embedded.scala'
         'begin': '(\\$\\{)'
         'patterns': [
-          {
-            'name': 'margin'
-            'match': '^\\s*\\|'
-          }
-          {
-            'include': '#code'
-          }
+          { 'include': '$self' }
         ]
         'end': '(\\})'
         'captures':
-          '1':
-            'name': 'delimiters.scala'
+          '0':
+            'name': 'punctuation.section.embedded.scala'
       }
       {
-        'match': '\\$(\\w+)'
+        'name': 'source.embedded.scala'
+        'match': '(\\$)\\w+'
         'captures':
           '1':
-            'name': 'variable'
-      }
-      {
-        'name': "scala.expression.embedded"
-        'begin': '(""")'
-        'patterns': [
-          { 'include': "#code"}
-        ]
-        'end': '(""")'
-        'captures':
-          '1':
-            'name': 'delimiters.scala'
-      }
-    ]
-  'quasiquotes-patterns':
-    'patterns': [
-      {
-        'include': '#interpolation-expression'
-      }
-      {
-        'include': '#code'
+            'name': 'punctuation.section.embedded.scala'
       }
     ]
   'interpolations':
     'patterns': [
       {
-        'name': "scala.quasiquote.embedded"
-        'begin': '(q""")'
-        'patterns': [
-          { 'include': "#quasiquotes-patterns"}
-        ]
-        'end': '(""")'
-        'captures':
-          '1':
-            'name': 'delimiters.scala'
-      }
-      {
-        'name': "scala.quasiquote.embedded"
-        'begin': '(q")'
-        'patterns': [
-          { 'include': "#quasiquotes-patterns"}
-        ]
-        'end': '(")'
-        'captures':
-          '1':
-            'name': 'delimiters.scala'
-      }
-      {
-        'name': "scala.string-interpolation"
-        'begin': '(s""")'
+        'name': 'string.quoted.triple.scala'
+        'begin': '\\w+"""'
         'beginCaptures':
-          '1':
-            'name': 'start'
-        'end': '(""")'
+          '0':
+            'name': 'punctuation.definition.string.begin.scala'
+        'end': '"""'
         'endCaptures':
-          '1':
-            'name': 'end.scala'
+          '0':
+            'name': 'punctuation.definition.string.end.scala'
         'patterns': [
           { 'include': '#interpolation-expression' }
         ]
       }
       {
-        'name': "scala.string-interpolation"
-        'begin': '(s")'
+        'name': "string.quoted.double.scala"
+        'begin': '\\w+"'
         'beginCaptures':
-          '1':
-            'name': 'start'
-        'end': '(")'
+          '0':
+            'name': 'punctuation.definition.string.begin.scala'
+        'end': '"'
         'endCaptures':
-          '1':
-            'name': 'end.scala'
+          '0':
+            'name': 'punctuation.definition.string.end.scala'
         'patterns': [
           { 'include': '#interpolation-expression' }
         ]


### PR DESCRIPTION
So I made some changes to the grammar file to better support highlighting for s/f/raw/whatever prefixed strings (#10 and #32). I tried to line up the class names with the ones used for similar interpolations in other languages from official atom repos. I've been using this for a while and it works well for me.

Than being said, I'm not sure how compatible it is with different highlighting syntaxes (some cursory perusing of the different syntaxes seem to show a lot of differences). I use solarized-dark, but feedback on other schemes would be good and might necessitate changes.


Here's what it looks like on my machine:
![screenshot 2015-08-21 18 34 42](https://cloud.githubusercontent.com/assets/2963448/9420407/588f7a5e-4833-11e5-80ff-364a37dd327b.png)
![screenshot 2015-08-21 18 34 54](https://cloud.githubusercontent.com/assets/2963448/9420409/5b2e0424-4833-11e5-9069-20f24ecc57b9.png)
