### PR TITLE
Added a snippet to start a scaladoc block

### DIFF
--- a/snippets/language-scala.cson
+++ b/snippets/language-scala.cson
@@ -86,3 +86,6 @@
   'with':
     'prefix': 'with'
     'body': 'with ${1:Any}'
+  'scaladoc':
+    'prefix': '/**'
+    'body': '/**\n * $0\n */'


### PR DESCRIPTION
With this snippet typing /** followed by tab will cause a basic scaladoc block to be started.