### PR TITLE
Update character literal matches to support '''

### DIFF
--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -32,7 +32,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.character.begin.scala'
-    'end': '\''
+    'end': '\'(?!\')'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.character.end.scala'
@@ -47,11 +47,7 @@
         'name': 'invalid.illegal.unrecognized-character-escape.scala'
       }
       {
-        'match': '[^\']{2,}'
-        'name': 'invalid.illegal.character-literal-too-long'
-      }
-      {
-        'match': '(?<!\')[^\']'
+        'match': '.{2,}(?=\')'
         'name': 'invalid.illegal.character-literal-too-long'
       }
     ]


### PR DESCRIPTION
This PR updates the character literal end capture regex with a negative lookahead for an single quote character to avoid capturing an single quote as the character literal (i.e. `val c = '''`. This is the same method by which #32 was fixed.

The matcher for a too-long character also had to be updated to correctly show an error for several single quotes in a row `val c = ''''`. There were two matchers for too-long char literals, and I replaced them with one generic matcher. It looks like it's working to me (catches several characters inside the single quotes, doesn't mark escaped or unicode chars as errors).

@gangstead could you sanity check this change for me? I've also not done a release for this package before (I'm familiar with the process after following the thread in #33), but if you'd rather handle it that would be cool.