### PR TITLE
Revert too-long char literal match changes

### DIFF
--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -47,7 +47,11 @@
         'name': 'invalid.illegal.unrecognized-character-escape.scala'
       }
       {
-        'match': '.{2,}(?=\')'
+        'match': '[^\']{2,}'
+        'name': 'invalid.illegal.character-literal-too-long'
+      }
+      {
+        'match': '(?<!\')[^\']'
         'name': 'invalid.illegal.character-literal-too-long'
       }
     ]


### PR DESCRIPTION
This PR reverts the changes to the invalid character length matchers I introduced in #37. Turns out they broke highlighting for two character literals used on the same line (see #39). Oops.

Reverting that change mans that `val tooLong = ''''` will not be highlighted properly as an error, but I can't find an elegant way to do it. It might need its own matcher, and from playing around, that matcher will probably need to deal with escaped single-quotes as well. I'd like to release this first while I think about it / experiment.