### PR TITLE
Add missing symbolic operator characters. Remove non-keywords.

### DIFF
--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -316,7 +316,7 @@
             'name': 'keyword.declaration.scala'
           '2':
             'name': 'entity.name.function.declaration'
-        'match': '(?x)\n\t\t\t\t\t\t\\b(def)\\s+\n\t\t\t\t\t\t(`[^`]+`|[_$a-zA-Z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[(\\t ])|[_$a-zA-Z][_$a-zA-Z0-9]*|[-?~><^+*%:!#|/@\\\\]+)'
+        'match': '(?x)\n\t\t\t\t\t\t\\b(def)\\s+\n\t\t\t\t\t\t(`[^`]+`|[_$a-zA-Z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[(\\t ])|[_$a-zA-Z][_$a-zA-Z0-9]*|[!#%&*+\-/:<=>?@\\\\^|~]+)'
       }
       {
         'captures':
@@ -334,7 +334,7 @@
             'name': 'keyword.declaration.scala'
           '2':
             'name': 'entity.name.type.declaration'
-        'match': '\\b(type)\\s+(`[^`]+`|[_$a-zA-Z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[\\t ])|[_$a-zA-Z][_$a-zA-Z0-9]*|[-?~><^+*%:!#|/@\\\\]+)'
+        'match': '\\b(type)\\s+(`[^`]+`|[_$a-zA-Z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[\\t ])|[_$a-zA-Z][_$a-zA-Z0-9]*|[!#%&*+\-/:<=>?@\\\\^|~]+)'
       }
       {
         'captures':
@@ -344,7 +344,7 @@
             'name': 'keyword.declaration.volatile.scala'
           '3':
             'name': 'entity.name.val.declaration'
-        'match': '\\b(?:(val)|(var))\\s+(?:(`[^`]+`|[_$a-zA-Z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[\\t ])|[_$a-zA-Z][_$a-zA-Z0-9]*|[-?~><^+*%:!#|/@\\\\]+)|(?=\\())'
+        'match': '\\b(?:(val)|(var))\\s+(?:(`[^`]+`|[_$a-zA-Z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[\\t ])|[_$a-zA-Z][_$a-zA-Z0-9]*|[!#%&*+\-/:<=>?@\\\\^|~]+)|(?=\\())'
       }
       {
         'captures':
@@ -454,20 +454,16 @@
         'name': 'keyword.control.exception.scala'
       }
       {
-        'match': '(<-|←|->|→|=>|⇒|\\?|\\:+|@|\\|)+'
-        'name': 'keyword.operator.scala'
+        'captures':
+          '2':
+            'name': 'keyword.operator.scala'
+        'match': '([^!#%&*+\-/:<=>?@\\\\^|~_])(<-|←|->|→|=>|⇒|\\?|\\:+|@|\\|)+([^!#%&*+\-/:<=>?@\\\\^|~])'
       }
       {
-        'match': '(==?|!=|<=|>=|<>|<|>)'
-        'name': 'keyword.operator.comparison.scala'
-      }
-      {
-        'match': '(\\-|\\+|\\*|/(?![/*])|%|~)'
-        'name': 'keyword.operator.arithmetic.scala'
-      }
-      {
-        'match': '(!|&&|\\|\\|)'
-        'name': 'keyword.operator.logical.scala'
+        'captures':
+          '2':
+            'name': 'keyword.operator.assignment.scala'
+        'match': '([^!#%&*+\-/:<=>?@\\\\^|~_])(=)([^!#%&*+\-/:<=>?@\\\\^|~])'
       }
     ]
   'meta-brackets':
@@ -494,8 +490,8 @@
             'name': 'variable.parameter.scala'
           '2':
             'name': 'meta.colon.scala'
-        'comment': 'We do not match param names that start with a Capitol letter'
-        'match': '(?<=[^\\._$a-zA-Z0-9])(`[^`]+`|[_$a-z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[\\t ])|[_$a-z][_$a-zA-Z0-9]*|[-?~><^+*%:!#|/@\\\\]+)\\s*(:)\\s+'
+        'comment': 'We do not match param names that start with a Capital letter'
+        'match': '(?<=[^\\._$a-zA-Z0-9])(`[^`]+`|[_$a-z][_$a-zA-Z0-9]*(?:_[^\\s])(?=[\\t ])|[_$a-z][_$a-zA-Z0-9]*|[!#%&*+\-/:<=>?@\\\\^|~]+)\\s*(:)\\s+'
       }
     ]
   'qualifiedClassName':


### PR DESCRIPTION
Symbolic operators can contain `&` and `=`, so add these to relevant
regexes.
Fix typo on "Capitol".
Comparison, logical and arithmetic "keywords" are actually just methods
in scala, so remove these. They also caused problems by matching
against parts of other methods, like `===`.
Add new match for assignment with `=`, making sure this doesn't match
symbolic operators containing = character.
Make sure that operators like `<-`, `=>` don't match against symbolic
operators containing them as a substring.
