### PR TITLE
fix fira code trigraphs

### DIFF
--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -455,11 +455,11 @@
         'name': 'keyword.control.exception.scala'
       }
       {
-        'match': '(<-|←|->|→|=>|⇒|~>|\\?|\\:+|@|\\|)+'
+        'match': '(<-|←|->>|->|→|=>|⇒|~>|>>=|\\?|\\:+|@|\\|)+'
         'name': 'keyword.operator.scala'
       }
       {
-        'match': '(==?|!=|<=|>=|<>|<|>)'
+        'match': '\\b(=|==|===|!=|<=|>=|<>|<|>)\\b'
         'name': 'keyword.operator.comparison.scala'
       }
       {

--- a/grammars/scala.cson
+++ b/grammars/scala.cson
@@ -459,7 +459,7 @@
         'name': 'keyword.operator.scala'
       }
       {
-        'match': '\\b(=|==|===|!=|<=|>=|<>|<|>)\\b'
+        'match': '\\b(===|==|=|!=|<=|>=|<>|<|>)\\b'
         'name': 'keyword.operator.comparison.scala'
       }
       {


### PR DESCRIPTION
This seems to fix the followig Fira Code trigraph ligatures:

- `->>` (used by shapeless records) 
- `>>=` (scalaz/cats flatMap alias)
- `===` (scalaz/cats sane equality) 

There are no obvious ill effects, but I don't really know what I'm doing.

![image](https://cloud.githubusercontent.com/assets/1200131/22180820/451f078c-e030-11e6-91ac-956b3cdab27c.png)
